### PR TITLE
Add Fair Register CRDT

### DIFF
--- a/examples/CRDT Verification/build.sbt
+++ b/examples/CRDT Verification/build.sbt
@@ -5,6 +5,6 @@ version := "0.2-SNAPSHOT"
 scalaVersion := "2.13.1"
 
 libraryDependencies ++= Seq(
-  "org.verifx" %% "verifx" % "1.0.1",
+  "org.verifx" %% "verifx" % "1.0.2",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )

--- a/examples/CRDT Verification/build.sbt
+++ b/examples/CRDT Verification/build.sbt
@@ -5,6 +5,6 @@ version := "0.2-SNAPSHOT"
 scalaVersion := "2.13.1"
 
 libraryDependencies ++= Seq(
-  "org.verifx" %% "verifx" % "1.0.2",
+  "org.verifx" %% "verifx" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
@@ -2,20 +2,20 @@ import org.verifx.crdtproofs.LamportClock
 
 object RegisterOps {
     // A register has a single `write` operation.
-    enum RegisterOp {
-        Write(value: Int)
+    enum RegisterOp[V] {
+        Write(value: V)
     }
 }
 
-class TaggedOp(t: LamportClock, o: RegisterOp)
+class TaggedOp[V](t: LamportClock, o: RegisterOp[V])
 
-class History(ops: Set[TaggedOp])
+class History[V](ops: Set[TaggedOp[V]])
 
 // Fairness ensures that every replica can eventually have one of its writes selected.
 // The history is a partially ordered set of updates.
 // `membership` is the number of replicas in the system.
-class FairRegister(history: History, membership: Int) {
-    def append(taggedOp: TaggedOp): FairRegister = {
+class FairRegister[V](history: History[V], membership: Int) {
+    def append(taggedOp: TaggedOp[V]): FairRegister[V] = {
         val newHistory = new History(
             this.history.ops.add(taggedOp)
         )
@@ -35,9 +35,9 @@ class FairRegister(history: History, membership: Int) {
         (idx + this.membership - leader) % this.membership
     }
 
-    def read(): Set[TaggedOp] = {
-        this.history.ops.filter((taggedOp: TaggedOp) =>
-            this.history.ops.forall((to: TaggedOp) =>
+    def read(): Set[TaggedOp[V]] = {
+        this.history.ops.filter((taggedOp: TaggedOp[V]) =>
+            this.history.ops.forall((to: TaggedOp[V]) =>
                 to == taggedOp || this.compare(to.t, taggedOp.t)
             )
         )
@@ -57,11 +57,11 @@ object FairRegister {
     // For every causal history of a fair register and any two values `x` and `y`,
     // if a query returns both `x` and `y`, then `x = y`.
     //! VeriFx does not expose a general method for obtaining the size of a set.
-    proof FairRegister_returns_at_most_one_value {
+    proof FairRegister_returns_at_most_one_value[V] {
         forall(
-            r: FairRegister,
-            x: TaggedOp,
-            y: TaggedOp
+            r: FairRegister[V],
+            x: TaggedOp[V],
+            y: TaggedOp[V]
         ) {
             (r.read().contains(x) && r.read().contains(y)) =>: (
                 x == y
@@ -71,10 +71,10 @@ object FairRegister {
 
     //* Validity
     // A fair register does not return values that were not written.
-    proof FairRegister_returns_only_written_values {
+    proof FairRegister_returns_only_written_values[V] {
         forall(
-            r: FairRegister,
-            x: TaggedOp
+            r: FairRegister[V],
+            x: TaggedOp[V]
         ) {
             (r.read().contains(x)) =>: (
                 r.history.ops.contains(x)
@@ -86,11 +86,11 @@ object FairRegister {
     // For every causal history of a fair register and any two updates `u` and `u'`,
     // if `u` is returned by a query, then either `u = u'` or `u` is more recent
     // than `u'` according to the `compare` function.
-    proof FairRegister_returns_most_recent_write {
+    proof FairRegister_returns_most_recent_write[V] {
         forall(
-            r: FairRegister,
-            chosen: TaggedOp,
-            candidate: TaggedOp
+            r: FairRegister[V],
+            chosen: TaggedOp[V],
+            candidate: TaggedOp[V]
         ) {
             (r.read().contains(chosen)
             && r.history.ops.contains(chosen)
@@ -108,9 +108,9 @@ object FairRegister {
     // - strongly connected
 
     // `compare` is a strongly connected order.
-    proof FairRegister_compare_totality {
+    proof FairRegister_compare_totality[V] {
         forall(
-            r: FairRegister,
+            r: FairRegister[V],
             t1: LamportClock,
             t2: LamportClock
         ) {
@@ -121,9 +121,9 @@ object FairRegister {
     }
 
     // `compare` is an asymmetric order.
-    proof FairRegister_compare_is_asymmetric {
+    proof FairRegister_compare_is_asymmetric[V] {
         forall(
-            r: FairRegister,
+            r: FairRegister[V],
             t1: LamportClock,
             t2: LamportClock
         ) {
@@ -134,9 +134,9 @@ object FairRegister {
     }
 
     // `compare` is a transitive order.
-    proof FairRegister_compare_is_transitive {
+    proof FairRegister_compare_is_transitive[V] {
         forall(
-            r: FairRegister,
+            r: FairRegister[V],
             t1: LamportClock,
             t2: LamportClock,
             t3: LamportClock
@@ -162,8 +162,8 @@ object FairRegister {
     //! a counter value that ranks it last. Assuming no Byzantine behavior, the counter
     //! value is determined only by the execution and scheduling of operations and is
     //! not under the control of any replica.
-    proof FairRegister_each_replica_can_win_infinitely_many_rounds {
-        forall(r: FairRegister, i: Int, n: Int) {
+    proof FairRegister_each_replica_can_win_infinitely_many_rounds[V] {
+        forall(r: FairRegister[V], i: Int, n: Int) {
             (r.membership > 0 && r.validReplica(i) && n >= 0) =>:
                 exists(c: Int) {
                     c == i + n * r.membership &&
@@ -180,10 +180,10 @@ object FairRegister {
     //* Convergence
     // For any two fair-register replicas `r1` and `r2` with the same set of operations
     // in their histories, `r1` and `r2` return the same value.
-    proof Fair_register_convergence {
+    proof Fair_register_convergence[V] {
         forall(
-            r1: FairRegister,
-            r2: FairRegister
+            r1: FairRegister[V],
+            r2: FairRegister[V]
         ) {
             (r1 == r2) =>: (
                 r1.read() == r2.read()

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
@@ -1,0 +1,192 @@
+import org.verifx.crdtproofs.LamportClock
+
+object RegisterOps {
+    // A register has a single `write` operation
+    enum RegisterOp {
+        Write(value: Int)
+    }
+}
+
+class TaggedOp(t: LamportClock, o: RegisterOp)
+
+class History(ops: Set[TaggedOp])
+
+// Fairness is a nice property that ensure that all replicas can eventually have their writes selected.
+// history is a partially ordered set of updates
+// membership is the number of replicas in the system
+class FairRegister(history: History, membership: Int) {
+    def append(taggedOp: TaggedOp): FairRegister = {
+        val newHistory = new History(
+            this.history.ops.add(taggedOp)
+        )
+        new FairRegister(newHistory, this.membership)
+    }
+
+    // Returns true if t1 < t2
+    // the winner is the participating replica with the smallest positive rank,
+    // i.e. the one nearest to the leader in the round-robin order.
+    def compare(t1: LamportClock, t2: LamportClock): Boolean = {
+        t1.counter < t2.counter || (t1.counter == t2.counter && this.rank(t1) < this.rank(t2))
+    }
+
+    def rank(t: LamportClock): Int = {
+        val leader = t.counter % this.membership
+        val idx = t.replica
+        (idx + this.membership - leader) % this.membership
+    }
+
+    def read(): Set[TaggedOp] = {
+        this.history.ops.filter((taggedOp: TaggedOp) =>
+            this.history.ops.forall((to: TaggedOp) =>
+                to == taggedOp || this.compare(to.t, taggedOp.t)
+            )
+        )
+    }
+
+    //* Helper functions for proofs
+
+    def validReplica(replica: Int): Boolean =
+        replica >= 0 && replica < this.membership
+
+    def validClock(t: LamportClock): Boolean =
+        t.counter >= 0 && this.validReplica(t.replica)
+}
+
+object FairRegister {
+    //* Uniqueness
+    // For all fair register causal history, given two values x, y, if the set returned
+    // by a query contains both x and y, then x = y.
+    //! VeriFx does not expose a general method to get the size of a set.
+    proof FairRegister_returns_at_most_one_value {
+        forall(
+            r: FairRegister,
+            x: TaggedOp,
+            y: TaggedOp
+        ) {
+            (r.read().contains(x) && r.read().contains(y)) =>: (
+                x == y
+            )
+        }
+    }
+
+    //* Validity
+    // FairRegister does not return values that were not written.
+    proof FairRegister_returns_only_written_values {
+        forall(
+            r: FairRegister,
+            x: TaggedOp
+        ) {
+            (r.read().contains(x)) =>: (
+                r.history.ops.contains(x)
+            )
+        }
+    }
+
+    //* Validity
+    // for all fair register causal history, given two updates u, u', if u is returned 
+    // by a query, then either u = u' or u is more recent than u' according to the `compare` function.
+    proof FairRegister_returns_most_recent_write {
+        forall(
+            r: FairRegister,
+            chosen: TaggedOp,
+            candidate: TaggedOp
+        ) {
+            (r.read().contains(chosen)
+            && r.history.ops.contains(chosen)
+            && r.history.ops.contains(candidate)) =>: (
+                candidate == chosen || r.compare(candidate.t, chosen.t)
+            )
+        }
+    }
+
+    //* Total order
+    //  Proof that compare is a total order over valid lamport clocks, i.e. it is:
+    // - reflexive
+    // - antisymmetric
+    // - transitive
+    // - strongly connected
+
+    // Compare is a strongly connected order
+    proof FairRegister_compare_totality {
+        forall(
+            r: FairRegister,
+            t1: LamportClock,
+            t2: LamportClock
+        ) {
+            (r.membership > 0 && r.validClock(t1) && r.validClock(t2)) =>: (
+                t1 == t2 || r.compare(t1, t2) || r.compare(t2, t1)
+            )
+        }
+    }
+
+    // Compare is an antisymmetric order
+    proof FairRegister_compare_is_asymmetric {
+        forall(
+            r: FairRegister,
+            t1: LamportClock,
+            t2: LamportClock
+        ) {
+            (r.membership > 0 && r.validClock(t1) && r.validClock(t2) && r.compare(t1, t2)) =>: (
+                !r.compare(t2, t1)
+            )
+        }
+    }
+
+    // Compare is a transitive order
+    proof FairRegister_compare_is_transitive {
+        forall(
+            r: FairRegister,
+            t1: LamportClock,
+            t2: LamportClock,
+            t3: LamportClock
+        ) {
+            (r.membership > 0
+            && r.validClock(t1)
+            && r.validClock(t2)
+            && r.validClock(t3)
+            && r.compare(t1, t2)
+            && r.compare(t2, t3)) =>: (
+                r.compare(t1, t3)
+            )
+        }
+    }
+
+    //* Fairness: 
+    // For all causal histories of a fair register r, all replicas i, and all positive integer n,
+    // there exists a lamport clock c >= n such that replica i wins the conflict
+    // against any other replica j with the same clock
+    //! NB: This is weak notion of fairness, because it only ensures that there is no
+    //! replica that is always ranked last, whatever the value of the counter.
+    //! However, the counter can still be used to starve a replica, by always picking
+    //! a value of the counter that ranks it last. Assuming no Byzantine beahvior,
+    //! the value of the counter is determined only by the execution and scheduling of operations,
+    //! and is not under the control of any replica.
+    proof FairRegister_each_replica_can_win_infinitely_many_rounds {
+        forall(r: FairRegister, i: Int, n: Int) {
+            (r.membership > 0 && r.validReplica(i) && n >= 0) =>:
+                exists(c: Int) {
+                    c == i + n * r.membership &&
+                    c >= n &&
+                    forall(j: Int) {
+                        (r.validReplica(j) && j != i) =>: (
+                            r.rank(new LamportClock(i, c)) < r.rank(new LamportClock(j, c))
+                        )
+                    }
+                }
+        }
+    }
+
+    //* Convergence
+    // For all fair register causal history, given two replicas r1, r2 with the same set of operations
+    // in their history, then r1 and r2 return the same value.
+    proof Fair_register_convergence {
+        forall(
+            r1: FairRegister,
+            r2: FairRegister
+        ) {
+            (r1 == r2) =>: (
+                r1.read() == r2.read()
+            )
+        }
+    }
+}

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
@@ -1,7 +1,7 @@
 import org.verifx.crdtproofs.LamportClock
 
 object RegisterOps {
-    // A register has a single `write` operation
+    // A register has a single `write` operation.
     enum RegisterOp {
         Write(value: Int)
     }
@@ -11,9 +11,9 @@ class TaggedOp(t: LamportClock, o: RegisterOp)
 
 class History(ops: Set[TaggedOp])
 
-// Fairness is a nice property that ensure that all replicas can eventually have their writes selected.
-// history is a partially ordered set of updates
-// membership is the number of replicas in the system
+// Fairness ensures that every replica can eventually have one of its writes selected.
+// The history is a partially ordered set of updates.
+// `membership` is the number of replicas in the system.
 class FairRegister(history: History, membership: Int) {
     def append(taggedOp: TaggedOp): FairRegister = {
         val newHistory = new History(
@@ -22,9 +22,9 @@ class FairRegister(history: History, membership: Int) {
         new FairRegister(newHistory, this.membership)
     }
 
-    // Returns true if t1 < t2
-    // the winner is the participating replica with the smallest positive rank,
-    // i.e. the one nearest to the leader in the round-robin order.
+    // Returns true if `t1` precedes `t2`.
+    // The winning replica is the participating replica with the smallest positive rank,
+    // i.e. the replica closest to the leader in round-robin order.
     def compare(t1: LamportClock, t2: LamportClock): Boolean = {
         t1.counter < t2.counter || (t1.counter == t2.counter && this.rank(t1) < this.rank(t2))
     }
@@ -54,9 +54,9 @@ class FairRegister(history: History, membership: Int) {
 
 object FairRegister {
     //* Uniqueness
-    // For all fair register causal history, given two values x, y, if the set returned
-    // by a query contains both x and y, then x = y.
-    //! VeriFx does not expose a general method to get the size of a set.
+    // For every causal history of a fair register and any two values `x` and `y`,
+    // if a query returns both `x` and `y`, then `x = y`.
+    //! VeriFx does not expose a general method for obtaining the size of a set.
     proof FairRegister_returns_at_most_one_value {
         forall(
             r: FairRegister,
@@ -70,7 +70,7 @@ object FairRegister {
     }
 
     //* Validity
-    // FairRegister does not return values that were not written.
+    // A fair register does not return values that were not written.
     proof FairRegister_returns_only_written_values {
         forall(
             r: FairRegister,
@@ -82,9 +82,10 @@ object FairRegister {
         }
     }
 
-    //* Validity
-    // for all fair register causal history, given two updates u, u', if u is returned 
-    // by a query, then either u = u' or u is more recent than u' according to the `compare` function.
+    //* Recency
+    // For every causal history of a fair register and any two updates `u` and `u'`,
+    // if `u` is returned by a query, then either `u = u'` or `u` is more recent
+    // than `u'` according to the `compare` function.
     proof FairRegister_returns_most_recent_write {
         forall(
             r: FairRegister,
@@ -100,13 +101,13 @@ object FairRegister {
     }
 
     //* Total order
-    //  Proof that compare is a total order over valid lamport clocks, i.e. it is:
+    // Proof that `compare` is a total order over valid Lamport clocks, i.e. it is:
     // - reflexive
     // - antisymmetric
     // - transitive
     // - strongly connected
 
-    // Compare is a strongly connected order
+    // `compare` is a strongly connected order.
     proof FairRegister_compare_totality {
         forall(
             r: FairRegister,
@@ -119,7 +120,7 @@ object FairRegister {
         }
     }
 
-    // Compare is an antisymmetric order
+    // `compare` is an asymmetric order.
     proof FairRegister_compare_is_asymmetric {
         forall(
             r: FairRegister,
@@ -132,7 +133,7 @@ object FairRegister {
         }
     }
 
-    // Compare is a transitive order
+    // `compare` is a transitive order.
     proof FairRegister_compare_is_transitive {
         forall(
             r: FairRegister,
@@ -151,16 +152,16 @@ object FairRegister {
         }
     }
 
-    //* Fairness: 
-    // For all causal histories of a fair register r, all replicas i, and all positive integer n,
-    // there exists a lamport clock c >= n such that replica i wins the conflict
-    // against any other replica j with the same clock
-    //! NB: This is weak notion of fairness, because it only ensures that there is no
-    //! replica that is always ranked last, whatever the value of the counter.
-    //! However, the counter can still be used to starve a replica, by always picking
-    //! a value of the counter that ranks it last. Assuming no Byzantine beahvior,
-    //! the value of the counter is determined only by the execution and scheduling of operations,
-    //! and is not under the control of any replica.
+    //* Fairness
+    // For every causal history of a fair register `r`, every replica `i`, and every
+    // non-negative integer `n`, there exists a Lamport clock `c >= n` such that
+    // replica `i` wins the conflict against every other replica `j` with the same counter.
+    //! NB: This is a weak notion of fairness because it only ensures that no replica
+    //! is always ranked last, regardless of the counter value.
+    //! However, the counter can still be used to starve a replica by always choosing
+    //! a counter value that ranks it last. Assuming no Byzantine behavior, the counter
+    //! value is determined only by the execution and scheduling of operations and is
+    //! not under the control of any replica.
     proof FairRegister_each_replica_can_win_infinitely_many_rounds {
         forall(r: FairRegister, i: Int, n: Int) {
             (r.membership > 0 && r.validReplica(i) && n >= 0) =>:
@@ -177,8 +178,8 @@ object FairRegister {
     }
 
     //* Convergence
-    // For all fair register causal history, given two replicas r1, r2 with the same set of operations
-    // in their history, then r1 and r2 return the same value.
+    // For any two fair-register replicas `r1` and `r2` with the same set of operations
+    // in their histories, `r1` and `r2` return the same value.
     proof Fair_register_convergence {
         forall(
             r1: FairRegister,

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
@@ -82,7 +82,7 @@ object FairRegister {
         }
     }
 
-    //* Recency
+    //* Validity
     // For every causal history of a fair register and any two updates `u` and `u'`,
     // if `u` is returned by a query, then either `u = u'` or `u` is more recent
     // than `u'` according to the `compare` function.

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/registers/FairRegister.vfx
@@ -1,4 +1,6 @@
 import org.verifx.crdtproofs.LamportClock
+import org.verifx.crdtproofs.lemmas.CmRDT
+import org.verifx.crdtproofs.lemmas.CmRDTProof1
 
 object RegisterOps {
     // A register has a single `write` operation.
@@ -14,12 +16,33 @@ class History[V](ops: Set[TaggedOp[V]])
 // Fairness ensures that every replica can eventually have one of its writes selected.
 // The history is a partially ordered set of updates.
 // `membership` is the number of replicas in the system.
-class FairRegister[V](history: History[V], membership: Int) {
-    def append(taggedOp: TaggedOp[V]): FairRegister[V] = {
+class FairRegister[V](clock: LamportClock, history: History[V], membership: Int) extends CmRDT[RegisterOp[V], TaggedOp[V], FairRegister[V]] {
+    override def reachable(): Boolean =
+        this.membership > 0 && this.validClock(this.clock)
+
+    override def compatibleS(that: FairRegister[V]): Boolean =
+        this.membership == that.membership && this.clock.replica != that.clock.replica
+
+    def write(value: V): TaggedOp[V] =
+        new TaggedOp(this.clock.increment(), new Write(value))
+
+    def prepare(op: RegisterOp[V]): TaggedOp[V] = op match {
+        case Write(value) => this.write(value)
+    }
+
+    def effect(msg: TaggedOp[V]): FairRegister[V] =
+        this.append(msg)
+
+    private def append(taggedOp: TaggedOp[V]): FairRegister[V] = {
         val newHistory = new History(
             this.history.ops.add(taggedOp)
         )
-        new FairRegister(newHistory, this.membership)
+        val newClock =
+            if (this.clock.replica == taggedOp.t.replica)
+                taggedOp.t
+            else
+                this.clock
+        new FairRegister(newClock, newHistory, this.membership)
     }
 
     // Returns true if `t1` precedes `t2`.
@@ -50,9 +73,12 @@ class FairRegister[V](history: History[V], membership: Int) {
 
     def validClock(t: LamportClock): Boolean =
         t.counter >= 0 && this.validReplica(t.replica)
+
+    override def equals(that: FairRegister[V]): Boolean =
+        this.history == that.history && this.membership == that.membership
 }
 
-object FairRegister {
+object FairRegister extends CmRDTProof1[RegisterOp, TaggedOp, FairRegister] {
     //* Uniqueness
     // For every causal history of a fair register and any two values `x` and `y`,
     // if a query returns both `x` and `y`, then `x = y`.
@@ -174,20 +200,6 @@ object FairRegister {
                         )
                     }
                 }
-        }
-    }
-
-    //* Convergence
-    // For any two fair-register replicas `r1` and `r2` with the same set of operations
-    // in their histories, `r1` and `r2` return the same value.
-    proof Fair_register_convergence[V] {
-        forall(
-            r1: FairRegister[V],
-            r2: FairRegister[V]
-        ) {
-            (r1 == r2) =>: (
-                r1.read() == r2.read()
-            )
         }
     }
 }

--- a/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
+++ b/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
@@ -523,4 +523,47 @@ class ProofTests extends FlatSpec with Prover {
     val graph = ("UWMultidigraph", "UWMultidigraph_validity")
     prove(graph)
   }
+
+  ////////////////////////////////////////
+  // Fair Register CRDT //
+  ////////////////////////////////////////
+
+  "FairRegister" should "return at most one value" in {
+    val register = ("FairRegister", "FairRegister_returns_at_most_one_value")
+    prove(register)
+  }
+
+  it should "return the most recent write" in {
+    val register = ("FairRegister", "FairRegister_returns_most_recent_write")
+    prove(register)
+  }
+
+  it should "have a total compare order" in {
+    val register = ("FairRegister", "FairRegister_compare_totality")
+    prove(register)
+  }
+
+  it should "have an asymmetric compare order" in {
+    val register = ("FairRegister", "FairRegister_compare_is_asymmetric")
+    prove(register)
+  }
+
+  it should "have a transitive compare order" in {
+    val register = ("FairRegister", "FairRegister_compare_is_transitive")
+    prove(register)
+  }
+
+  it should "show each replica wins infinitely many rounds" in {
+    val register =
+      (
+        "FairRegister",
+        "FairRegister_each_replica_can_win_infinitely_many_rounds"
+      )
+    prove(register)
+  }
+
+  it should "converge" in {
+    val register = ("FairRegister", "Fair_register_convergence")
+    prove(register)
+  }
 }

--- a/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
+++ b/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
@@ -563,7 +563,7 @@ class ProofTests extends FlatSpec with Prover {
   }
 
   it should "converge" in {
-    val register = ("FairRegister", "Fair_register_convergence")
+    val register = ("FairRegister", "is_a_CmRDT")
     prove(register)
   }
 }

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -38,6 +38,7 @@ The types are:
 | Multi-Value Register                       | P    | pure/registers/PureMVRegister.vfx      |
 | Last-Writer-Wins Register                  | S    | registers/LWWRegister.vfx              |
 | Last-Writer-Wins Register                  | O    | registers/OpBasedLWWRegister.vfx       |
+| FairRegister                               | O    | registers/FairRegister.vfx             |
 | Grow-Only Set                              | O    | sets/OpBasedGSet.vfx                   |
 | Grow-Only Set                              | S    | sets/GSet.vfx                          |
 | Grow-Only Set                              | D    | sets/DeltaGSet.vfx                     |


### PR DESCRIPTION
Rebased follow-up to #8 (originally authored by @leo-olivier) on top of latest `main` after the modulo operator from #6 was merged.

## Summary
- Adds the `FairRegister` CRDT and its proofs (CmRDT trait, generic value, convergence, fairness properties)
- 5 commits replayed cleanly on top of `main`; the modulo-related commits from #8 were dropped automatically (already in `main` via #6)

## Conflict resolution
- `ProofTests.scala`: both `main` and this branch added new test blocks after the `PureMultidigraph` "converge" test. Kept both — `PureMultidigraph` extras (from `main`) first, then the `FairRegister` section.

## Why a new PR
PR #8 lives on a fork and couldn't be force-pushed from this side. This PR supersedes #8, which will be closed.