### PR TITLE
Add Record CRDT

### DIFF
--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/pure/record/PureRecord2.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/pure/record/PureRecord2.vfx
@@ -1,0 +1,147 @@
+import org.verifx.crdtproofs.VersionVector
+import org.verifx.crdtproofs.pure.ResettableCRDT
+
+/*
+ * A Record-2 is a composite pure op-based CRDT with two independent fields.
+ * The record does not define conflict resolution itself: every update is routed
+ * to the child CRDT of the targeted field, and that child resolves its own
+ * concurrent operations.
+ * 
+ * In a sense, a Record CRDT is simply an object or product type, with no particular semantics.
+ */
+
+//! VeriFx does not support variadic generics, so we define a Record-2 CRDT with two fields.
+//! It is easy to see that the proofs here generalize to a Record-n.
+
+object Record2Ops {
+  enum Record2Op[Field1Op, Field2Op] {
+    UpdateField1(op: Field1Op) |
+    UpdateField2(op: Field2Op)
+  }
+}
+
+// Returned value of a Record-2 CRDT read operation.
+// The value is the product of the fields.
+class Record2Value[Field1Value, Field2Value](
+  field1: Field1Value,
+  field2: Field2Value
+)
+
+// A field of a Record
+class Field[Log, Op, Value](
+  child: ResettableChild[Log, Op, Value],
+  log: Log
+)
+
+class Record2Log[
+  Field1Log, Field1Op, Field1Value,
+  Field2Log, Field2Op, Field2Value
+](
+  field1: Field[Field1Log, Field1Op, Field1Value],
+  field2: Field[Field2Log, Field2Op, Field2Value]
+) extends ResettableCRDT[
+  Record2Op[Field1Op, Field2Op],
+  Record2Value[Field1Value, Field2Value],
+  Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value]
+] {
+  def copy(
+    newField1: Field[Field1Log, Field1Op, Field1Value],
+    newField2: Field[Field2Log, Field2Op, Field2Value]
+  ): Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value] =
+    new Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value](
+      newField1,
+      newField2
+    )
+
+  // Apply an operation to the Record-2 CRDT. The operation is routed to the child CRDT of the targeted field.
+  // Operations on different fields commute because they modify disjoint logs.
+  def effect(op: Record2Op[Field1Op, Field2Op], t: VersionVector): Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value] = op match {
+    case UpdateField1(u) =>
+      this.copy(
+        new Field[Field1Log, Field1Op, Field1Value](
+          this.field1.child,
+          this.field1.child.effect(this.field1.log, u, t)
+        ),
+        this.field2
+      )
+
+    case UpdateField2(u) =>
+      this.copy(
+        this.field1,
+        new Field[Field2Log, Field2Op, Field2Value](
+          this.field2.child,
+          this.field2.child.effect(this.field2.log, u, t)
+        )
+      )
+  }
+
+  // Reset the Record-2 CRDT to a given version vector. The reset propagates to the child CRDTs of each field.
+  def reset(t: VersionVector, conservative: Boolean): Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value] =
+    this.copy(
+      new Field[Field1Log, Field1Op, Field1Value](
+        this.field1.child,
+        this.field1.child.reset(this.field1.log, t, conservative)
+      ),
+      new Field[Field2Log, Field2Op, Field2Value](
+        this.field2.child,
+        this.field2.child.reset(this.field2.log, t, conservative)
+      )
+    )
+
+  // Recursively read the value of each field
+  def read(): Record2Value[Field1Value, Field2Value] =
+    new Record2Value[Field1Value, Field2Value](
+      this.field1.child.applyRead(this.field1.log),
+      this.field2.child.applyRead(this.field2.log)
+    )
+}
+
+object PureRecord2 {
+  /*
+   * Concurrent Record2 updates commute. Updates to the same field commute
+   * because that field's child CRDT supplies the effect commutation law.
+   * Updates to different fields commute because they modify disjoint logs.
+   */
+  proof Record2_converges[
+    Field1Log, Field1Op, Field1Value,
+    Field2Log, Field2Op, Field2Value
+  ] {
+    forall(
+      r: Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value],
+      op1: Record2Op[Field1Op, Field2Op],
+      op2: Record2Op[Field1Op, Field2Op],
+      t1: VersionVector,
+      t2: VersionVector
+    ) {
+      (t1.concurrent(t2) &&
+        // Versions are well-formed
+        t1.vector.forall((n: Int) => n >= 0) &&
+        t2.vector.forall((n: Int) => n >= 0) &&
+        t1.vector.size == t2.vector.size &&
+        // The child CRDTs are correct
+        (
+          op1 match {
+            case UpdateField1(u1) => op2 match {
+              case UpdateField1(u2) =>
+                r.field1.child.effectsCommute(r.field1.log, u1, t1, u2, t2)
+
+              case UpdateField2(_) =>
+                true
+            }
+
+            case UpdateField2(u1) => op2 match {
+              case UpdateField1(_) =>
+                true
+
+              case UpdateField2(u2) =>
+                r.field2.child.effectsCommute(r.field2.log, u1, t1, u2, t2)
+            }
+          }
+        )
+      ) =>: {
+        r.effect(op1, t1).effect(op2, t2) ==
+        r.effect(op2, t2).effect(op1, t1)
+      }
+    }
+  }
+}

--- a/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/pure/record/PureRecord2.vfx
+++ b/examples/CRDT Verification/src/main/verifx/org/verifx/crdtproofs/pure/record/PureRecord2.vfx
@@ -144,4 +144,69 @@ object PureRecord2 {
       }
     }
   }
+
+  /*
+  * The Record-2 is a correct resettable CRDT.
+  */
+
+  proof update_reset[
+    Field1Log, Field1Op, Field1Value,
+    Field2Log, Field2Op, Field2Value
+  ] {
+    forall(
+      r: Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value],
+      op: Record2Op[Field1Op, Field2Op],
+      effectTime: VersionVector,
+      resetTime: VersionVector,
+      conservative: Boolean
+    ) {
+      (
+        effectTime.concurrent(resetTime) &&
+        // Version vectors are well-formed
+        effectTime.vector.forall((n: Int) => n >= 0) &&
+        resetTime.vector.forall((n: Int) => n >= 0) &&
+        effectTime.vector.size == resetTime.vector.size &&
+        // The child is a resettable CRDT
+        (
+          op match {
+            case UpdateField1(u) =>
+              r.field1.child.effectResetCommutes(r.field1.log, u, effectTime, resetTime, conservative)
+
+            case UpdateField2(u) =>
+              r.field2.child.effectResetCommutes(r.field2.log, u, effectTime, resetTime, conservative)
+          }
+        )
+      ) =>: {
+        r.effect(op, effectTime).reset(resetTime, conservative) ==
+        r.reset(resetTime, conservative).effect(op, effectTime)
+      }
+    }
+  }
+
+  proof reset_reset[
+    Field1Log, Field1Op, Field1Value,
+    Field2Log, Field2Op, Field2Value
+  ] {
+    forall(
+      r: Record2Log[Field1Log, Field1Op, Field1Value, Field2Log, Field2Op, Field2Value],
+      resetTime1: VersionVector,
+      resetTime2: VersionVector,
+      conservative1: Boolean,
+      conservative2: Boolean
+    ) {
+      (
+        resetTime1.concurrent(resetTime2) &&
+        // Version vectors are well-formed
+        resetTime1.vector.forall((n: Int) => n >= 0) &&
+        resetTime2.vector.forall((n: Int) => n >= 0) &&
+        resetTime1.vector.size == resetTime2.vector.size &&
+        // The child is a resettable CRDT
+        r.field1.child.resetsCommute(r.field1.log, resetTime1, resetTime2, conservative1, conservative2) &&
+        r.field2.child.resetsCommute(r.field2.log, resetTime1, resetTime2, conservative1, conservative2)
+      ) =>: {
+        r.reset(resetTime1, conservative1).reset(resetTime2, conservative2) ==
+        r.reset(resetTime2, conservative2).reset(resetTime1, conservative1)
+      }
+    }
+  }
 }

--- a/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
+++ b/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
@@ -503,6 +503,14 @@ class ProofTests extends FlatSpec with Prover {
     prove(record)
   }
 
+  it should "be a resettable CRDT" in {
+    val proofs = List(
+      ("PureRecord2", "update_reset"),
+      ("PureRecord2", "reset_reset"),
+    )
+    proofs.foreach(proof => prove(proof))
+  }
+
   ////////////////////////////////////////
   // Pure Op-based Update-Wins Labeled MultiDiGraph CRDT //
   ////////////////////////////////////////

--- a/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
+++ b/examples/CRDT Verification/src/test/scala/org/verifx/crdtproofs/ProofTests.scala
@@ -495,6 +495,15 @@ class ProofTests extends FlatSpec with Prover {
   }
 
   ////////////////////////////////////////
+  // Pure Op-based Record CRDT //
+  ////////////////////////////////////////
+
+  "PureRecord2" should "converge" in {
+    val record = ("PureRecord2", "Record2_converges")
+    prove(record)
+  }
+
+  ////////////////////////////////////////
   // Pure Op-based Update-Wins Labeled MultiDiGraph CRDT //
   ////////////////////////////////////////
 


### PR DESCRIPTION
*This PR depends on #10 and should not be merged before it.*

This pull request introduces Pure Record-2, a pure operation-based CRDT. Record-2 is a composite pure op-based CRDT with two independent fields. The record does not define conflict resolution itself: every update is routed to the child CRDT of the targeted field, and that child resolves its own concurrent operations. In a sense, a Record CRDT is simply an object or product type, with no particular semantics.

The proofs establish the following properties:
- Record-2 converges provided that its nested child is a correct resettable CRDT;
- Record-2 is itself a resettable CRDT.
